### PR TITLE
Update MySQLPlugin.cpp

### DIFF
--- a/MySQLPlugin.cpp
+++ b/MySQLPlugin.cpp
@@ -372,12 +372,11 @@ void CMySQLPlugin::OnScript_Fetch_Row()
                 pluginError("Houston, we got a problem: unnamed column!");
                 return;
             }
-            if(row[i] == NULL){
-                Plugin_Scr_AddString("");
-            }
-            else{
+            if(row[i] == NULL)
+                Plugin_Scr_AddUndefined();
+            else
                 Plugin_Scr_AddString(row[i]);
-            }
+                
             Plugin_Scr_AddArrayKey(Plugin_Scr_AllocString(field->name));
         }
     }

--- a/MySQLPlugin.cpp
+++ b/MySQLPlugin.cpp
@@ -372,7 +372,12 @@ void CMySQLPlugin::OnScript_Fetch_Row()
                 pluginError("Houston, we got a problem: unnamed column!");
                 return;
             }
-            Plugin_Scr_AddString(row[i]);
+            if(row[i] == NULL){
+                Plugin_Scr_AddString("");
+            }
+            else{
+                Plugin_Scr_AddString(row[i]);
+            }
             Plugin_Scr_AddArrayKey(Plugin_Scr_AllocString(field->name));
         }
     }


### PR DESCRIPTION
In some query like the one below, the columns may return NULL values which will cause segmentaion issue shutdowns. So as the discussion in [issue 7](https://github.com/callofduty4x/mysql/issues/7), I suggest to push an empty string or undefined.

Ex query:

```
SELECT MAX(player_score) AS max_score, COUNT(player_id) AS player_cnt
FROM table
WHERE condition 
```

If there is no record in the table, the column max_score will be NULL and player_cnt will be zero. This will probably cause segmentaion issues. So pushing undefined or empty string if some column has NULL value can fix the segmentation error.