### PR TITLE
Bug Fixes

### DIFF
--- a/MySQLPlugin.cpp
+++ b/MySQLPlugin.cpp
@@ -223,7 +223,6 @@ void CMySQLPlugin::OnScript_Affected_Rows()
 
     int idx = getHandleIndexForScriptArg(0);
     checkConnection(idx);
-    checkQuery(idx);
 
     Plugin_Scr_AddInt(mysql_affected_rows(&m_MySQL[idx]));
 }
@@ -428,7 +427,11 @@ void CMySQLPlugin::OnScript_Fetch_Rows()
         Plugin_Scr_MakeArray();
         for (unsigned int i = 0; i < col_count; ++i)
         {
-            Plugin_Scr_AddString(rows[i]);
+            if(rows[i] == NULL)
+                Plugin_Scr_AddUndefined();
+            else
+                Plugin_Scr_AddString(rows[i]);
+            
             Plugin_Scr_AddArrayKey(keyArrayIndex[i]);
         }
         Plugin_Scr_AddArray();

--- a/MySQLPlugin.cpp
+++ b/MySQLPlugin.cpp
@@ -223,6 +223,7 @@ void CMySQLPlugin::OnScript_Affected_Rows()
 
     int idx = getHandleIndexForScriptArg(0);
     checkConnection(idx);
+    checkQuery(idx);
 
     Plugin_Scr_AddInt(mysql_affected_rows(&m_MySQL[idx]));
 }

--- a/MySQLPlugin.hpp
+++ b/MySQLPlugin.hpp
@@ -58,6 +58,7 @@ private:
     MYSQL m_MySQL[MYSQL_CONNECTION_COUNT];
     MYSQL_RES* m_MySQLResults[MYSQL_CONNECTION_COUNT];
     bool m_MySQLInUse[MYSQL_CONNECTION_COUNT];
+    unsigned int m_MYSQLErrNo[MYSQL_CONNECTION_COUNT];
 };
 
 void InitPlugin();


### PR DESCRIPTION
1. In **OnScript_Affected_Rows()**, using **_checkQuery(idx)_** will trigger _"mysql_query' must be called before"_ error because there is always NULL in m_MySQLResults[ ] when we execute **INSERT, UPDATE and DELETE** queries.

2. Fixed segmentation issue in **OnScript_Fetch_Rows()** function.